### PR TITLE
Fix building optional sources

### DIFF
--- a/add_config.py
+++ b/add_config.py
@@ -34,8 +34,7 @@ heap_impl = env.GetProjectOption("custom_freertos_heap_impl", "heap_4.c")
 
 extra_features = env.GetProjectOption("custom_freertos_features", None)
 if extra_features is not None:
-    extra_features = config.get("env:" + env.get("PIOENV"), "custom_freertos_features").split(",")
-    extra_features = [x.strip() for x in extra_features]
+    extra_features = [x.strip() for x in extra_features.split(",")]
 else:
     extra_features = []
 


### PR DESCRIPTION
Bug in add_config.py fails to add the extra sources when building. Error message was "config not defined". I believe this is what caused the problem in issue #2. Did a quick fix.