### PR TITLE
Correct foldername for cortex-m7 port files

### DIFF
--- a/add_config.py
+++ b/add_config.py
@@ -27,7 +27,7 @@ foldername = {
     "cortex-m3": "ARM_CM3",
     "cortex-m0": "ARM_CM0",
     "cortex-m4": "ARM_CM4F",
-    "cortex-m7": "ARM_CM7"
+    "cortex-m7": "ARM_CM7/r0p1"
 }[cpu_name]
 
 heap_impl = env.GetProjectOption("custom_freertos_heap_impl", "heap_4.c")


### PR DESCRIPTION
This change was necessary to use the lib with STM32F723-DISCO board.
